### PR TITLE
add caching to isEthUnit

### DIFF
--- a/src/components/Swap/SwapContainer.jsx
+++ b/src/components/Swap/SwapContainer.jsx
@@ -49,7 +49,7 @@ class SwapContainer extends Component {
     componentDidMount() {
         document.title = 'DEUS swap';
         setTimeout(() => this.initialAmounts(), 500);
-        const isEthUnit = localStorage.getItem("isEthUnit");
+        const isEthUnit = localStorage.getItem("isEthUnit")
         this.setState({isEthUnit: isEthUnit !== "false"})
     }
 

--- a/src/components/Swap/SwapContainer.jsx
+++ b/src/components/Swap/SwapContainer.jsx
@@ -49,6 +49,8 @@ class SwapContainer extends Component {
     componentDidMount() {
         document.title = 'DEUS swap';
         setTimeout(() => this.initialAmounts(), 500);
+        const isEthUnit = localStorage.getItem("isEthUnit");
+        this.setState({isEthUnit: isEthUnit !== "false"})
     }
 
 
@@ -357,7 +359,9 @@ class SwapContainer extends Component {
 
     handleUnit = () => {
         const { isEthUnit } = this.state
-        this.setState({ isEthUnit: !isEthUnit })
+        const updatedIsEthUnit = !isEthUnit
+        this.setState({ isEthUnit: updatedIsEthUnit })
+        localStorage.setItem("isEthUnit", String(updatedIsEthUnit))
     }
 
 


### PR DESCRIPTION
This PR added a cache layer for the base conversion rate choices. The goal for this PR is that when I want to check DEUS price I want to refresh it and click "Show Dollar Price". So with this I can straight see the latest price.

<img width="247" alt="Screenshot 2020-12-21 at 1 07 49 PM" src="https://user-images.githubusercontent.com/15358452/102741522-87a32d80-438d-11eb-9cdd-2c438e61967f.png">
